### PR TITLE
fixes #13: Use default build artifact naming

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,15 +21,6 @@
         <plugins>
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>make-assembly</id>
-                        <configuration>
-                            <appendAssemblyId>false</appendAssemblyId>
-                            <finalName>${project.artifactId}</finalName>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>org.eclipse.jetty</groupId>


### PR DESCRIPTION
Required for publishing via Github Actions.